### PR TITLE
Rename Get-BigText to Write-BigText

### DIFF
--- a/BigAsciiChars.psm1
+++ b/BigAsciiChars.psm1
@@ -297,12 +297,31 @@ function GetLetterColumn
         }
     }
 }
-function Get-BigText
+
+function Write-BigText
 {
     param
     (
-        [string]$Text,
-        [int]$CharacterSeparation = 1
+        # The text to write
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0)]
+        [string]
+        $Text,
+
+        [Parameter(Mandatory = $false)]
+        [int]
+        $CharacterSeparation = 1,
+
+        [Parameter(Mandatory = $false)]
+        [char]
+        $OutChar = "#",
+
+        [Parameter(Mandatory = $false)]
+        [char]
+        $EmptyChar = " ",
+
+        [System.Collections.IDictionary]
+        $Dictionary = $Codes
+
     )
 
     $TextArray = New-Object string[] 5
@@ -313,14 +332,45 @@ function Get-BigText
         [void]$RowSB.Clear()
         foreach ($char in $Text.ToCharArray())
         {
-            [void]$RowSB.Append((GetLetterRow -Char $char -Row $i))
-            [void]$RowSB.Append(" " * $CharacterSeparation)
+            [void]$RowSB.Append((GetLetterRow -Char $char -Row $i -OutChar $OutChar -EmptyChar $EmptyChar -Dictionary $Dictionary))
+            [void]$RowSB.Append($EmptyChar, $CharacterSeparation)
         }
 
         $TextArray[$i] = $RowSB.ToString().TrimEnd()
     }
     
     $TextArray
+}
+
+
+function Write-SpinText
+{
+    param(
+        [string]
+        $Text,
+
+        [int]
+        $LoopCount = 1,
+
+        [int]
+        $FrameDelay = 100
+    )
+
+    begin
+    {
+        $SpinArray = "!/—\¡—\".ToCharArray()
+        Clear-Host
+    }
+    end
+    {
+        for ($i = 0; $i -lt ($SpinArray.Length * $LoopCount); $i++)
+        {
+            [System.Console]::SetCursorPosition(0,0)
+            $OutChar = ($SpinArray[$i % $SpinArray.Length])
+            Write-BigText -Text $Text -OutChar $OutChar
+            Start-Sleep -Milliseconds $FrameDelay
+        }
+    }
 }
 
 <#


### PR DESCRIPTION
For consistency, change the verb on Write-BigText
Updated the parameters of Write-BigText to accept what the GetLetterRow function will accept.
Also added a demo taking advantage of the parameter input to write text in a spinning font (ooooOOOOooohh)