### PR TITLE
Add inmodulescope for mocks

### DIFF
--- a/tests/BigAsciiChars.tests.ps1
+++ b/tests/BigAsciiChars.tests.ps1
@@ -83,12 +83,23 @@ Describe "New-BAFont" {
     }
 }
 
-Describe "Write-ScrollText" {
-    It "Writes to screen with text input and exits" {
-        Write-ScrollText -Text "P" -Width 2 -FrameDelay 0 | Should -BeNullOrEmpty
-    }
-    It "Writes to screen with byte input and exits" {
-        Write-ScrollText -Bytes @(255) -Width 2 -FrameDelay 0 | Should -BeNullOrEmpty
+# Mocks requiring scope amendment
+InModuleScope -ModuleName $ModuleName {
+    Describe "Write-ScrollText" {
+        Context "Mock Write-Host" {
+            Mock Write-Host -MockWith { [void]"" } -ModuleName $ModuleName
+            Mock Out-Host -MockWith { [void]"" } -ModuleName $ModuleName
+            It "Writes to screen with text input and exits" {
+                Write-ScrollText -Text "P" -Width 2 -FrameDelay 0 | Should -BeNullOrEmpty
+                Assert-MockCalled -CommandName Write-Host -Times 2
+                Assert-MockCalled -CommandName Out-Host -Times 6
+            }
+            It "Writes to screen with byte input and exits" {
+                Write-ScrollText -Bytes @(255) -Width 2 -FrameDelay 0 | Should -BeNullOrEmpty
+                Assert-MockCalled -CommandName Write-Host -Times 2
+                Assert-MockCalled -CommandName Out-Host -Times 2
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Write-Host and Out-Host were polluting the test output  with the results from write-scrolltext
Added InModuleScope and mocks for those functions to remove this pollution